### PR TITLE
Update README for setup calendar_watcher

### DIFF
--- a/services/calendar_watcher/README.org
+++ b/services/calendar_watcher/README.org
@@ -1,6 +1,6 @@
 * CalendarWatcher
 
-  Watch Google calenar and send events via gRPC to upstreams.
+  Watch Google calendar and send events via gRPC to upstreams.
 
 ** Installation
 

--- a/services/calendar_watcher/README.org
+++ b/services/calendar_watcher/README.org
@@ -22,6 +22,23 @@
      $ gem install calendar_watcher
    #+END_SRC
 
+** Setup
+
+   CalendarWatcher requires authorization to Google Calendar API.
+
+   1. Get OAuth 2.0 CLIENT_ID/CLIENT_SECRET at
+      https://console.developers.google.com
+
+   2. Create a config file by invoking init command.
+     #+BEGIN_SRC ruby
+     $ bundle exec exe/calendar_watcher init
+     #+END_SRC
+
+   3. Authorize by invoking auth command.
+     #+BEGIN_SRC ruby
+     $ bundle exec exe/calendar_watcher auth
+     #+END_SRC
+
 ** Usage
 
    TODO: Write usage instructions here


### PR DESCRIPTION
#16 に対する PR である．

calendar_watcher は [nomlab/goohub](https://github.com/nomlab/goohub) を Gem としてインストールして実装されている．
ここで，goohub では，Googleカレンダー API に Authorize するためのコマンドとして以下の2つのコマンドが用意されている．

+ `init`: OAuth2.0 のクライアントID とクライアントシークレットの情報を格納した `config.yml` を作成するコマンド
+ `auth`: OAuth2.0 で Googleカレンダー API の認可を得るコマンド

このため，calendar_watcher においても上記コマンドを利用することができ，別途セットアップ用のコマンドを実装する必要がないと考えた．

そこで，本 PR では，上記に示したコマンドを用いて，Googleカレンダー API の認可を得る手順を README.md に追記した．( 25a3cf9 )
