### PR TITLE
Make it possible to specify port number when launch server

### DIFF
--- a/services/informant/README.org
+++ b/services/informant/README.org
@@ -55,16 +55,18 @@ TBA...
 1. informant のサーバを起動
 
   #+BEGIN_SRC sh
-  $ python informant_server.py
+  $ python informant_server.py [PORT]
   #+END_SRC
 
-  上記を実行すると， =http://localhost:50051= でサーバが待機する．
+  上記を実行すると， =http://localhost:[PORT]= でサーバが待機する．ポート番号 =[PORT]= は指定しなかった場合， =50051= となる．
 
 ** Test
 1. テストスクリプトの実行
 
+  =[PORT]= に =informant_server.py= 起動時に指定したポート番号を指定して以下のコマンドを実行する．
+
   #+BEGIN_SRC sh
-  $ python informant_test.py
+  $ python informant_test.py [PORT]
   #+END_SRC
 
   上記を実行すると，指定したワークスペースのチャンネルに以下のメッセージが送信される．

--- a/services/informant/informant_server.py
+++ b/services/informant/informant_server.py
@@ -16,6 +16,11 @@ _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 SLACK_MESSAGE_API = 'https://slack.com/api/chat.postMessage'
 
 try:
+    port = sys.argv[1]
+except:
+    port = 50051
+
+try:
     settings = yaml.load(open('settings.yml','r'))
     SLACK_TOKEN =  settings['slack_token']
     SLACK_CHANNEL = settings['channel']
@@ -46,7 +51,7 @@ class Slack(service_pb2_grpc.SlackServicer):
 def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     service_pb2_grpc.add_SlackServicer_to_server(Slack(), server)
-    server.add_insecure_port('[::]:50051')
+    server.add_insecure_port('[::]:' + str(port))
     server.start()
     try:
         while True:

--- a/services/informant/informant_test.py
+++ b/services/informant/informant_test.py
@@ -6,10 +6,15 @@ import hiyoco.calendar.event_pb2 as event_pb2
 import hiyoco.calendar.event_pb2_grpc as event_pb2_grpc
 import hiyoco.informant.service_pb2 as service_pb2
 import hiyoco.informant.service_pb2_grpc as service_pb2_grpc
+import sys
 
+try:
+    port = sys.argv[1]
+except:
+    port = 50051
 
 def run():
-    channel = grpc.insecure_channel('localhost:50051')
+    channel = grpc.insecure_channel('localhost:' + str(port))
     stub = service_pb2_grpc.SlackStub(channel)
     response = stub.SayEvent(event_pb2.Event(summary='Test event',description="This is test"))
     print(response)


### PR DESCRIPTION
複数のサービスを同一ホストで動作させる際に，ポート番号を指定できたほうが良いと考えたため，サーバの起動時にポート番号を指定できるようにした．

以下のコマンドを実行しサーバを起動する．

```
$ python imformant_server.py [PORT]
```

また，テストはサーバ起動時に指定したポート番号を `[PORT]` に設定し，以下のコマンドを実行する．

```
$ python imformant_test.py [PORT]
```

サーバ起動とテストスクリプトの実行において， `[PORT]` に何も設定しなかった場合， `50051` が設定される．

また，上記の変更に伴い `README.org` を更新した．