### PR TITLE
Make it possible to specify port number when lounch server and test server

### DIFF
--- a/services/sounder/README.org
+++ b/services/sounder/README.org
@@ -40,16 +40,19 @@ TBA...
 
    Voice Kit で下記を実行する．
   #+BEGIN_SRC sh
-  $ python sounder_server.py
+  $ python sounder_server.py [PORT]
   #+END_SRC
 
-  上記を実行すると， =http://localhost:50051= でサーバが待機する．
+[PORT]はポート番号を表す．[PORT]は指定しなかった場合，50051となる．
+上記を実行すると， =http://localhost:[PORT]= でサーバが待機する．
+
 
 ** Test
 1. テストスクリプトの実行
 
+=sounder_server.py= 起動時に指定したポート番号を[PORT]に指定して，以下のコマンドを実行する．
   #+BEGIN_SRC sh
-  $ python sounder_client.py
+  $ python sounder_client.py [PORT]
   #+END_SRC
 
   上記を実行すると，soudner のサーバが Voice Kit を利用して以下の文章を発言する．

--- a/services/sounder/sounder_client.py
+++ b/services/sounder/sounder_client.py
@@ -4,8 +4,13 @@ import hiyoco.calendar.event_pb2_grpc
 import hiyoco.sounder.service_pb2
 import hiyoco.sounder.service_pb2_grpc
 
+try:
+    port = sys.argv[1]
+except:
+    port = 50051
+
 def run():
-    channel = grpc.insecure_channel('localhost:50051')
+    channel = grpc.insecure_channel('localhost' + str(port))
     stub = hiyoco.sounder.service_pb2_grpc.SounderStub(channel)
     response = stub.SayEvent(hiyoco.calendar.event_pb2.Event(summary='Test event',description="This is test"))
     print(response)

--- a/services/sounder/sounder_server.py
+++ b/services/sounder/sounder_server.py
@@ -11,6 +11,11 @@ import hiyoco.sounder.service_pb2_grpc
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
+try:
+    port = sys.argv[1]
+except:
+    port = 50051
+
 class Sounder(hiyoco.sounder.service_pb2_grpc.SounderServicer):
     def SayEvent(self, request, context):
         msg = "Summary is " + request.summary + "\n" + "Description is" + request.description + "\n"
@@ -20,7 +25,7 @@ class Sounder(hiyoco.sounder.service_pb2_grpc.SounderServicer):
 def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     hiyoco.sounder.service_pb2_grpc.add_SounderServicer_to_server(Sounder(), server)
-    server.add_insecure_port('[::]:50051')
+    server.add_insecure_port('[::]:' + str(port))
     server.start()
     try:
         while True:


### PR DESCRIPTION
### 今回やったこと

+ #24 同様に，sounderのサーバを起動させる際にポート番号を指定できたほうがいいと考えた．
このため，コミットID 9821d8a にて，sounderのサーバ起動プログラムである`sounder_server.py`と，テストプログラムである`sounder_client.py`にてポート番号を指定できるようにした．
以下のコマンドで，`sounder_server.py`と`sounder_client.py`は動作する．
```
$ python sounder_server.py [PORT]
```
```
$ python sounder_client.py [PORT]
```

双方のコマンドにおける`[PORT]`は，ポート番号を指す．
指定がなかった場合は，`[PORT]`は50051となる．

+ また，コミットID 22a5eb8 にて，ポート番号の指定に関する記述をREADMEに追加した．