### PR TITLE
Add a rake task to compile .proto files and update README for calendar watcher 

### DIFF
--- a/services/calendar_watcher/README.org
+++ b/services/calendar_watcher/README.org
@@ -38,8 +38,7 @@
 
    2. Generate gRPC code:
      #+BEGIN_SRC ruby
-     $ chmod a+x compile_proto_ruby.sh
-     $ ./compile_proto_ruby.sh
+     $ bundle exec rake compile
      #+END_SRC
 
    To install this gem onto your local machine, run
@@ -47,7 +46,10 @@
    update the version number in
    =version.rb=, and then run =bundle exec rake release=, which will
    create a git tag for the version, push git commits and tags, and push
-   the =.gem= file to [[https://rubygems.org][rubygems.org]]
+   the =.gem= file to [[https://rubygems.org][rubygems.org]].
+   You don’t need to run =bundle exec rake compile= before running
+   =bundle exec rake install= or =bundle exec rake release= because
+   both of commands are dependencies of =bundle exec rake compile=.
 
 ** Contributing
 

--- a/services/calendar_watcher/Rakefile
+++ b/services/calendar_watcher/Rakefile
@@ -4,3 +4,10 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+task :compile do
+  sh "bin/grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/calendar/event.proto"
+  sh "bin/grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/calendar_watcher/service.proto"
+end
+
+task :build => :compile 

--- a/services/calendar_watcher/compile_proto_ruby.sh
+++ b/services/calendar_watcher/compile_proto_ruby.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-bin/grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/calendar/event.proto
-bin/grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/calendar_watcher/service.proto
-echo 'Generate grpc code into "lib/proto/hiyoco"'


### PR DESCRIPTION
#15 に対するPR

`.proto` ファイルのコンパイルを rake タスクとして追加するため， `calendar_watcher` の `Rakefile` を編集した．
具体的には以下のとおりである．
+  新たに `compile` という名前のタスクを追加
+  既存の `build` タスク と `compile` タスクが依存関係であることを記述

また，上記の変更に伴い， `README.org` を更新した．