### PR TITLE
Add message type Text to event.proto

### DIFF
--- a/proto/hiyoco/calendar/event.proto
+++ b/proto/hiyoco/calendar/event.proto
@@ -53,3 +53,10 @@ message Event {
 message Result {
   bool result = 1; /// Result
 }
+
+/**
+  Represents plain text
+*/
+message Text {
+  string body = 1 /// Text body
+}


### PR DESCRIPTION
もくもく会での議論にて，informantとsounderに対する予定の送受信は`event.proto`の`Event型`はなく，文字列で行うことになった．
このため，`event.proto`に以下のメッセージを追加した．
```
message Text {
  string body = 1 /// Text body
}
```