### PR TITLE
Modify sounder to receive message type Text

### DIFF
--- a/proto/hiyoco/sounder/service.proto
+++ b/proto/hiyoco/sounder/service.proto
@@ -11,5 +11,5 @@ option csharp_namespace = "Hiyoco.Sounder.Service";
   Service for handling SayEvent 
 */
 service Sounder {
-  rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
+  rpc SayEvent (hiyoco.calendar.Text) returns (hiyoco.calendar.Result) {}
 }

--- a/services/sounder/sounder_client.py
+++ b/services/sounder/sounder_client.py
@@ -12,7 +12,7 @@ except:
 def run():
     channel = grpc.insecure_channel('localhost:' + str(port))
     stub = hiyoco.sounder.service_pb2_grpc.SounderStub(channel)
-    response = stub.SayEvent(hiyoco.calendar.event_pb2.Event(summary='Test event',description="This is test"))
+    response = stub.SayEvent(hiyoco.calendar.event_pb2.Text(body='This is test'))
     print(response)
 
 

--- a/services/sounder/sounder_server.py
+++ b/services/sounder/sounder_server.py
@@ -18,7 +18,7 @@ except:
 
 class Sounder(hiyoco.sounder.service_pb2_grpc.SounderServicer):
     def SayEvent(self, request, context):
-        msg = "Summary is " + request.summary + "\n" + "Description is" + request.description + "\n"
+        msg = request.body
         aiy.audio.say(msg)
         return hiyoco.calendar.event_pb2.Result()
 


### PR DESCRIPTION
#29  同様に，もくもく会の議論にて，sounderは`event.proto`の`Event`型ではなく，文字列を受け取ることになった．
このため，`event.proto`の`Text`メッセージを受け取るようにsounderを変更した．