### PR TITLE
Add today_events command to calendar_watcher

### DIFF
--- a/examples/exec_today_events.sh
+++ b/examples/exec_today_events.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do
+    ../services/calendar_watcher/exe/calendar_watcher today_events;
+    sleep 60;
+done

--- a/services/calendar_watcher/lib/calendar_watcher/command.rb
+++ b/services/calendar_watcher/lib/calendar_watcher/command.rb
@@ -6,5 +6,6 @@ dir = File.dirname(__FILE__) + "/command"
 #    require "#{dir}/profile.rb"
 
 require "#{dir}/get_event.rb"
+require "#{dir}/today_events.rb"
 require "#{dir}/init.rb"
 require "#{dir}/auth.rb"

--- a/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
+++ b/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
@@ -1,0 +1,115 @@
+require "date"
+require "pp"
+
+class CalendarWatcherCLI < Clian::Cli
+  desc "today_events", "Show today's events."
+  option :format, :default => "json", :desc => "specify output format (json or prety)"
+
+  def today_events()
+    format = options[:format]
+    min = Date.today.strftime("%Y-%m-%dT00:00:00+09:00")
+    max = Date.today.strftime("%Y-%m-%dT23:59:59+09:00")
+
+    today_events = EventCollection.new
+
+    raw_calendars = client.list_calendar_lists()
+    calendars = Goohub::Resource::CalendarCollection.new(raw_calendars)
+
+    calendars.each do |c|
+      raw_events = client.list_events(c.id, time_max: max, time_min: min)
+
+      raw_events.items.each do |ev|
+        start_time = date_or_datetime(ev.start)
+        end_time = date_or_datetime(ev.end)
+
+        today_events << Event.new(start_time, end_time, ev.summary, ev.description)
+      end
+    end
+
+    if format == "json"
+      puts today_events.to_json
+    elsif format == "prety"
+      today_events.each do |ev|
+        puts ev.to_s
+        # TODO: Fix format
+        # ex)
+        #  10:00-12:00 meeting
+        #       allday someone's birthday
+      end
+    end
+  end
+
+  private
+
+  def date_or_datetime(date)
+    date.date_time || date.date
+  end
+
+end
+
+class Event
+  attr_reader :start_time, :end_time, :summary, :description
+
+  def initialize(start_time, end_time, summary, description)
+    @start_time, @end_time, @summary, @description =
+      start_time, end_time, summary, description
+  end
+
+  def to_s
+    "start:#{start_time}\nend:#{end_time}\nsummary:#{summary}\ndescription:#{description}\n"
+  end
+
+  def to_json(*arg)
+    to_hash.to_json
+  end
+
+  def to_hash
+    {
+      :start       => start_time,
+      :end         => end_time,
+      :summary     => summary,
+      :description => description
+    }
+  end
+
+  def self.from_hash(hash)
+    Event.new(DateTime.parse(hash["start"]),
+              DateTime.parse(hash["end"]),
+              hash["summary"],
+              hash["description"])
+  end
+
+  def self.from_json(json)
+    Event.from_hash(JSON.parse(json))
+  end
+end
+
+class EventCollection
+  include Enumerable
+
+  def initialize
+    @events = []
+  end
+
+  def <<(event)
+    @events << event
+  end
+
+  def each(&block)
+    @events.each do |ev|
+      yield ev
+    end
+  end
+
+  def to_json
+    @events.to_json
+  end
+
+  def self.from_json(json)
+    events = EventCollection.new
+    JSON.parse(json).each do |h|
+      events << Event.from_hash(h)
+    end
+    return events
+  end
+end


### PR DESCRIPTION
3f67ce2 : 実行した日の予定を取得して標準出力に出力する `today_events` コマンドを 'calendar_watcher' に追加した．

2e6ce60 : `today_events` を1分ごとに実行するスクリプト `exec_today_events.sh` を追加した．

以下に，`today_events` のヘルプを示す．
```
Usage:
  calendar_watcher today_events

Options:
  [--format=FORMAT]  # specify output format (json or prety)
                     # Default: json

Show today's events.
```
