### PR TITLE
Add compile script in examples

### DIFF
--- a/examples/compile_proto.sh
+++ b/examples/compile_proto.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+SH_PATH=$(dirname $0)
+
+bundle exec grpc_tools_ruby_protoc -I $SH_PATH/../proto/ --ruby_out=$SH_PATH --grpc_out=$SH_PATH $SH_PATH/../proto/hiyoco/calendar/event.proto
+Bundle exec grpc_tools_ruby_protoc -I $SH_PATH/../proto/ --ruby_out=$SH_PATH --grpc_out=$SH_PATH $SH_PATH/../proto/hiyoco/informant/service.proto
+bundle exec grpc_tools_ruby_protoc -I $SH_PATH/../proto/ --ruby_out=$SH_PATH --grpc_out=$SH_PATH $SH_PATH/../proto/hiyoco/sounder/service.proto


### PR DESCRIPTION
protoファイルのコンパイルスクリプトをexamples以下に追加した．
コンパイル対象のprotoファイルは以下の3つであり，生成後のファイルの言語はrubyである．
+ hiyoco/proto/hiyoco/calendar/event.proto
+ hiyoco/proto/hiyoco/informant/service.proto
+ hiyoco/proto/hiyoco/sounder/service.proto
