### PR TITLE
Add post_event_to_informant.rb

### DIFF
--- a/examples/post_event_to_informant.rb
+++ b/examples/post_event_to_informant.rb
@@ -1,0 +1,25 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
+require 'event'
+require 'json'
+
+require 'grpc'
+require "hiyoco/calendar/event_pb"
+require "hiyoco/informant/service_services_pb"
+
+def post(msg)
+  stub = Hiyoco::Informant::Informant::Stub.new("#{ARGV[0]}:#{ARGV[1]}", :this_channel_is_insecure)
+  stub.say_event(Hiyoco::Calendar::Text.new(body: "#{msg}"))
+end
+
+while json = STDIN.gets
+  events = EventCollection.from_json(json)
+  msg = []
+  msg << "Today's Events"
+  events.each do |event|
+    msg << "--------------------------"
+    msg << event.to_s
+  end
+  msg << "--------------------------"
+  post(msg.join("\n"))
+end


### PR DESCRIPTION
標準入力から受け取った JSON 形式のイベントを informant に gRPC で送信する．
第一引数に informant の起動しているホスト，第２引数にポート番号を指定する．
実行例を以下に示す．

```
bundle exec ruby post_event_to_informant.rb localhost 50051
```

標準入力から受け取ったイベントは，informant により以下のように Slack で発言される．

```
Today's Events
--------------------------
Summary:だれかさん誕生日
Description:おめでとう
Start at 2018-07-05 00:00
End at 2018-07-05 00:00
--------------------------
Summary:GN検討打合せ
Description:
Start at 2018-07-05 10:00
End at 2018-07-05 12:00
--------------------------
Summary:昼食会
Description:
Start at 2018-07-05 11:30
End at 2018-07-05 12:30
--------------------------
Summary:New開発
Description:
Start at 2018-07-05 13:00
End at 2018-07-05 16:00
--------------------------
Summary:テスト
Description:
Start at 2018-07-05 17:15
End at 2018-07-05 18:00
--------------------------
Summary:New開発打上
Description:きしもと食堂でやります
Start at 2018-07-05 18:30
End at 2018-07-05 20:30
--------------------------
```