### PR TITLE
Add post_event_to_sounder.rb

### DIFF
--- a/examples/post_event_to_sounder.rb
+++ b/examples/post_event_to_sounder.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
+require "grpc"
+require "hiyoco/sounder/service_services_pb"
+require_relative "event"
+
+host = ARGV[0]
+port = ARGV[1]
+
+while json = STDIN.gets
+  events = EventCollection.from_json(json.chomp)
+  events.each do |ev|
+    str = "#{ev.summary} is started after fifteen minutes"
+    stub = Hiyoco::Sounder::Sounder::Stub.new("#{host}:#{port}", :this_channel_is_insecure)
+    message = stub.say_event(Hiyoco::Calendar::Text.new(body: str )).result
+  end
+end


### PR DESCRIPTION
標準入力から受け取った予定をsounderに送信するスクリプトを作成した．
標準入力から受け取る予定はjson形式であり，`event.proto`に定義された`event`の配列である．
また，sounderへ予定を送信する際は，gRPCを利用する．
本スクリプトは，第一引数でホスト，第2引数でポートを指定する．
実行例を以下にしめす．
```
$ be ruby post_event_to_sounder.rb 172.21.50.8 50050
```
本スクリプトを実行すると，以下の内容でvoice kit は発言する．
```
<summary> is started afiter fifteen minutes.
```
なお，`<summary>`は，予定名である．
