### PR TITLE
Add stdout flush

### DIFF
--- a/examples/filter_not_out_yet.rb
+++ b/examples/filter_not_out_yet.rb
@@ -19,4 +19,5 @@ while json = gets
     unseen 
   end
   p events_not_out_yet.to_json
+  STDOUT.flush
 end


### PR DESCRIPTION
`hiyoco/examples` 以下の `filter_not_out_yet.rb` に `STDOUT.flush` を追加し，標準出力をフラッシュするようにした．