### PR TITLE
Add run.sh in examples/

### DIFF
--- a/examples/run.sh
+++ b/examples/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./exec_today_events.sh |tee >(ruby filter_before_15minutes.rb | ruby filter_not_out_yet.rb |bundle exec ruby post_event_to_sounder.rb 172.21.50.8 50050) >(./filter_not_out_yet.rb | ./once_day.rb | bundle exec ruby post_event_to_informant.rb localhost 50051)


### PR DESCRIPTION
examples以下のスクリプトを合わせて実行するスクリプト(`run.sh`)を追加した．
`run.sh`は，以下の環境で動作することを前提とする．
+ sounderが，host = 172.21.50.8, port = 50050で動作している
+ informantが，host = localhost, port = 50051で動作している
