### PR TITLE
Send today's events by grpc Event message

### DIFF
--- a/proto/hiyoco/calendar_watcher/service.proto
+++ b/proto/hiyoco/calendar_watcher/service.proto
@@ -14,3 +14,7 @@ service Sounder {
 service Informant {
   rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
 }
+
+service Filter {
+  rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
+}

--- a/services/calendar_watcher/exe/calendar_watcher_server
+++ b/services/calendar_watcher/exe/calendar_watcher_server
@@ -24,7 +24,7 @@ require "bundler/setup"
 require "grpc"
 require "hiyoco/calendar_watcher/service_services_pb"
 
-class SounderServer < Hiyoco::CalendarWatcher::Sounder::Service
+class FilterServer < Hiyoco::CalendarWatcher::Filter::Service
   def say_event(event, _unused_call)
     puts event.summary
     Hiyoco::Calendar::Result.new(result: true)
@@ -36,7 +36,7 @@ end
 def main
   s = GRPC::RpcServer.new
   s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
-  s.handle(SounderServer)
+  s.handle(FilterServer)
   s.run_till_terminated
 end
 


### PR DESCRIPTION
今日の予定を Google Calendar から取得し，出力する `today_events` コマンドに，grpc で予定を送信する機能を追加した．
具体的には，`output` オプションで `grpc:host:port` の形式を指定した際，grpc の `Event` メッセージを指定したホストとポートに送信する．

以下に，変更した `today_events` コマンドのヘルプを示す．
```
Usage:
  calendar_watcher today_events

Options:
  [--output=OUTPUT]  # specify output format (grpc:host:port or json or prety)
                     # Default: grpc:localhost:50051

Show today's events.
```