### PR TITLE
Add filter service

### DIFF
--- a/proto/hiyoco/filter/service.proto
+++ b/proto/hiyoco/filter/service.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package hiyoco.filter;
+
+import "hiyoco/calendar/event.proto";
+
+option java_package = "org.nomlab.hiyoco";
+option java_outer_classname = "FilterServiceProtos";
+option csharp_namespace = "Hiyoco.Filter.Service";
+
+service Filter {
+  rpc SayText (hiyoco.calendar.Text) returns (hiyoco.calendar.Result) {}
+  rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
+}

--- a/services/filter/Gemfile
+++ b/services/filter/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# gem "rails"
+gem "grpc"
+gem "grpc-tools"

--- a/services/filter/compile_proto.sh
+++ b/services/filter/compile_proto.sh
@@ -4,3 +4,4 @@ SH_PATH=$(dirname $0)
 
 bundle exec grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/calendar/event.proto
 bundle exec grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/filter/service.proto
+bundle exec grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/informant/service.proto

--- a/services/filter/compile_proto.sh
+++ b/services/filter/compile_proto.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+SH_PATH=$(dirname $0)
+
+bundle exec grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/calendar/event.proto
+bundle exec grpc_tools_ruby_protoc -I ../../proto/ --ruby_out=lib/proto --grpc_out=lib/proto ../../proto/hiyoco/filter/service.proto

--- a/services/filter/filter_client.rb
+++ b/services/filter/filter_client.rb
@@ -1,0 +1,31 @@
+# coding: utf-8
+this_dir = File.expand_path(File.dirname(__FILE__))
+lib_dir = File.join(this_dir, '/lib/proto')
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
+
+require 'grpc'
+require "hiyoco/calendar/event_pb"
+require "hiyoco/filter/service_pb"
+require "hiyoco/filter/service_services_pb"
+require 'date'
+
+def create_date(time)
+    gtime = Google::Protobuf::Timestamp.new
+    gtime.from_time(time)
+    d = Hiyoco::Calendar::Date.new(date: gtime)
+    return d
+end
+
+def main
+  start_time = DateTime.parse("2018-08-06T13:00:00+09:00")
+  end_time = DateTime.parse("2018-08-06T15:00:00+09:00")
+  summary = "第160回GN談話会"
+  description = nil
+
+  stub = Hiyoco::Filter::Filter::Stub.new('0.0.0.0:50051', :this_channel_is_insecure)
+  ev = Hiyoco::Calendar::Event.new(start: create_date(start_time), end: create_date(end_time), summary: summary, description: description)
+  message = stub.say_event(ev).result
+  puts message
+end
+
+main

--- a/services/filter/filter_client.rb
+++ b/services/filter/filter_client.rb
@@ -7,22 +7,24 @@ require 'grpc'
 require "hiyoco/calendar/event_pb"
 require "hiyoco/filter/service_pb"
 require "hiyoco/filter/service_services_pb"
-require 'date'
+require "google/protobuf/well_known_types"
 
 def create_date(time)
-    gtime = Google::Protobuf::Timestamp.new
-    gtime.from_time(time)
-    d = Hiyoco::Calendar::Date.new(date: gtime)
-    return d
+  gtime = Google::Protobuf::Timestamp.new
+  gtime.from_time(time)
+  d = Hiyoco::Calendar::Date.new(date: gtime)
+  date_or_time = Hiyoco::Calendar::DateOrTime.new
+  date_or_time.date = d
+  return date_or_time
 end
 
 def main
-  start_time = DateTime.parse("2018-08-06T13:00:00+09:00")
-  end_time = DateTime.parse("2018-08-06T15:00:00+09:00")
+  start_time = Time.new(2018, 8, 6, 13, 30, 0, "+09:00")
+  end_time = Time.new(2018, 8, 6, 15, 30, 0, "+09:00")
   summary = "第160回GN談話会"
-  description = nil
+  description = ""
 
-  stub = Hiyoco::Filter::Filter::Stub.new('0.0.0.0:50051', :this_channel_is_insecure)
+  stub = Hiyoco::Filter::Filter::Stub.new('0.0.0.0:50050', :this_channel_is_insecure)
   ev = Hiyoco::Calendar::Event.new(start: create_date(start_time), end: create_date(end_time), summary: summary, description: description)
   message = stub.say_event(ev).result
   puts message

--- a/services/filter/filter_server.rb
+++ b/services/filter/filter_server.rb
@@ -1,0 +1,29 @@
+this_dir = File.expand_path(File.dirname(__FILE__))
+lib_dir = File.join(this_dir, '/lib/proto')
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
+
+require 'grpc'
+require "hiyoco/calendar/event_pb"
+require "hiyoco/filter/service_pb"
+require "hiyoco/filter/service_services_pb"
+
+host = "localhost"
+port = 50051
+
+class FilterServer < Hiyoco::Filter::Filter::Service
+  def say_event(e, _unused_call)
+    stub = Hiyoco::Filter::Filter::Stub.new('0.0.0.0:50050', :this_channel_is_insecure)
+    str = "Summary:#{e.summary}\nDescription:#{e.description}\nStart at #{e.start_time.strftime("%Y-%m-%d %H:%M")}\nEnd at #{e.end_time.strftime("%Y-%m-%d %H:%M")}\n"
+    message = stub.say_event(Hiyoco::Calendar::Text.new(body: str )).result
+    puts message
+  end
+end
+
+def main
+  s = GRPC::RpcServer.new
+  s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
+  s.handle(FilterServer)
+  s.run_till_terminated
+end
+
+main

--- a/services/filter/filter_server.rb
+++ b/services/filter/filter_server.rb
@@ -6,22 +6,33 @@ require 'grpc'
 require "hiyoco/calendar/event_pb"
 require "hiyoco/filter/service_pb"
 require "hiyoco/filter/service_services_pb"
-
-host = "localhost"
-port = 50051
+require "hiyoco/informant/service_services_pb"
 
 class FilterServer < Hiyoco::Filter::Filter::Service
   def say_event(e, _unused_call)
-    stub = Hiyoco::Filter::Filter::Stub.new('0.0.0.0:50050', :this_channel_is_insecure)
-    str = "Summary:#{e.summary}\nDescription:#{e.description}\nStart at #{e.start_time.strftime("%Y-%m-%d %H:%M")}\nEnd at #{e.end_time.strftime("%Y-%m-%d %H:%M")}\n"
+    stub = Hiyoco::Informant::Informant::Stub.new('0.0.0.0:50051', :this_channel_is_insecure)
+    start_time = Time.at(e.start.date.date.seconds)
+    end_time = Time.at(e.end.date.date.seconds)
+    str = "Summary:#{e.summary}\nDescription:#{e.description}\nStart at #{start_time.strftime("%Y-%m-%d %H:%M")}\nEnd at #{end_time.strftime("%Y-%m-%d %H:%M")}\n"
     message = stub.say_event(Hiyoco::Calendar::Text.new(body: str )).result
     puts message
   end
 end
 
 def main
+  if ARGV[0] == nil then
+    host = "localhost"
+  else
+    host = ARGV[0]
+  end
+  if ARGV[1] == nil then
+    port = 50050
+  else
+    port = ARGV[1]
+  end
+
   s = GRPC::RpcServer.new
-  s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
+  s.add_http2_port("#{host}:#{port}", :this_port_is_insecure)
   s.handle(FilterServer)
   s.run_till_terminated
 end


### PR DESCRIPTION
## やったこと
+ calendar_watcherから受け取った予定を編集し，informantやsounderに送信するfilterというサービスを作成した．具体的には，以下のファイルを作成した．
    + `proto/hiyoco/filter/service.proto`: filterのprotoファイル
    + `services/filter/compile_proto.sh`: protoファイルのコンパイル用スクリプト
    + `services/filter/filter_server.rb`; filterのサーバ用プログラム
    + `services/filter/filter_client.rb`: filterのテスト用プログラム
+ しかし，filterのテストプログラムである`filter_client.rb`が未完成であるため，`filter_server.rb`のテストが行えていない．この原因は，`DateTime型`を`Google::Protobuf::Timestamp型`に変換する方法がわかっていないためである．calendar_watcherを参考にして変換処理を行う`create_time`メソッドを作成したが，`Google::Protobuf::Timestamp型`に`from_time`というメソッドがないというエラーが表示された．

## 今後の課題
+ `filter_server.rb`のテスト
+ READMEの作成
+ ポートの設定