### PR TITLE
Add generate documents section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # hiyoco
+
+[![CircleCI](https://circleci.com/gh/nomlab/hiyoco.svg?style=svg)](https://circleci.com/gh/nomlab/hiyoco)
+
 hiyocoは，複数のサービスによって構成されたアプリケーションであり，以下の機能をもつ．
 1.  Google カレンダーから予定を取得
 2.  取得した予定を，slackの特定のチャンネルに投稿
@@ -64,3 +67,30 @@ TBA...
   + 各サービスが利用する.protoファイルを格納する．
 + services
   + hiyocoを構成するサービスを格納する．
+  
+# Build and Test
+## Generate Markdown documents from .proto files
+`.proto`ファイルに記述されたコメントから，Markdownドキュメントを生成する．ドキュメント生成には，`protoc-gen-doc` を用いる．`protoc-gen-doc` とは，[Google Protocol Buffers](https://developers.google.com/protocol-buffers/) の compiler ( `protoc` ) のドキュメント生成用プラグインである．本リポジトリにおいてドキュメントを生成するには， `generate_docs.sh` または Circle CI を用いる2つの方法がある．生成されたドキュメントは `proto/docs` ディレクトリに格納される．
+
+### Using generate_docs.sh
+[`proto/generate_docs.sh`](https://github.com/nomlab/hiyoco/blob/master/proto/generate_docs.sh) から Markdown ドキュメントを生成する方法は以下の2つ．
+
+1. 公式の `protoc-gen-doc` のDocker imageを用いる．      
+参照先: [https://hub.docker.com/r/pseudomuto/protoc-gen-doc/](https://hub.docker.com/r/pseudomuto/protoc-gen-doc/)
+
+2. ローカルにインストールした `protoc-gen-doc` を用いる．   
+参照先: [https://github.com/pseudomuto/protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc)
+
+**Usage**  
+`hiyoco/proto` ディレクトリで `./generate_docs.sh` を実行する．
+```
+$ chmod +x generate_docs.sh
+
+# 実行方法は以下の3通りである．
+$ ./generate_docs.sh          # Use official docker image
+$ ./generate_docs.sh --local  # Use locally-installed protoc-gen-doc
+$ ./generate_docs.sh --debug  # Invoke shell prompt in docker container for debug
+```
+
+### Using Circle CI
+Circle CI は上記の `generate_docs.sh` を利用している．このため，編集された `.proto` ファイルが本リポジトリに push されると，Circle CIが `generate_docs.sh` を実行することによって `hiyoco/docs` 以下にある Markdown ドキュメントが更新される．Circle CI の設定は `config.yml` に記されている．


### PR DESCRIPTION
#52 に対するPR

[README.md](https://github.com/taccho918/hiyoco/blob/master/README.md) を編集した．具体的な変更は以下の通りである．
+ Circle CI の Status Badge を追加
+ `.proto` ファイルから Markdown ドキュメントを生成するスクリプトに関する記述を追加