### PR TITLE
Docker を用いて hiyoco/examples を運用する

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.5.1
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --path vendor/bundle
+
+COPY . .

--- a/examples/compile_proto.sh
+++ b/examples/compile_proto.sh
@@ -4,3 +4,4 @@ SH_PATH=$(dirname $0)
 bundle exec grpc_tools_ruby_protoc -I $SH_PATH/../proto/ --ruby_out=$SH_PATH --grpc_out=$SH_PATH $SH_PATH/../proto/hiyoco/calendar/event.proto
 bundle exec grpc_tools_ruby_protoc -I $SH_PATH/../proto/ --ruby_out=$SH_PATH --grpc_out=$SH_PATH $SH_PATH/../proto/hiyoco/informant/service.proto
 bundle exec grpc_tools_ruby_protoc -I $SH_PATH/../proto/ --ruby_out=$SH_PATH --grpc_out=$SH_PATH $SH_PATH/../proto/hiyoco/sounder/service.proto
+bundle exec grpc_tools_ruby_protoc -I $SH_PATH/../proto/ --ruby_out=$SH_PATH --grpc_out=$SH_PATH $SH_PATH/../proto/hiyoco/calendar_watcher/service.proto

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: ../services/informant/
     container_name: informant
     image: informant
+    # informant のポート番号は services/informant/Dockerfile で設定されている
     ports:
       - "50052:50052"
 
@@ -11,6 +12,7 @@ services:
     build: ../services/calendar_watcher/
     container_name: calendar_watcher
     image: calendar_watcher
+    # calendar_watcher today_events --output=grpc:hiyoco-example:<server.rb が起動しているポート>
     command: bash -c "while true; do bundle exec exe/calendar_watcher today_events --output=grpc:hiyoco-example:50051; sleep 60; done"
     volumes:
       - ./calendar_watcher:/root/.config/calendar_watcher
@@ -21,7 +23,11 @@ services:
     build: .
     container_name: hiyoco-example
     image: hiyoco-example
-    command: bash -c "bundle exec ruby server.rb | tee >(./filter_before_15minutes.rb | ./filter_not_out_yet.rb | bundle exec ruby post_event_to_sounder.rb 172.21.50.138 50050) >(./filter_not_out_yet.rb | ./once_day.rb | bundle exec ruby post_event_to_informant.rb informant 50052)"
+    # commnad 内で指定している引数は以下のとおり
+    # post_event_to_sounder.rb <VoiceKit の ホスト名(IP アドレス)> <VoiceKit で起動している sounder のポート番号>
+    # post_event_to_informant.rb <ホスト名(コンテナ名)> <informant のポート番号>
+    command: bash -c "bundle exec ruby server.rb | tee >(./filter_before_15minutes.rb | ./filter_not_out_yet.rb | bundle exec ruby post_event_to_sounder.rb 172.21.50.128 50050) >(./filter_not_out_yet.rb | ./once_day.rb | bundle exec ruby post_event_to_informant.rb informant 50052)"
+    # server.rb は 50051 番ポートで起動する
     ports:
       - "50051:50051"
     depends_on:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  informant:
+    build: ../services/informant/
+    container_name: informant
+    image: informant
+    ports:
+      - "50052:50052"
+
+  calendar_watcher:
+    build: ../services/calendar_watcher/
+    container_name: calendar_watcher
+    image: calendar_watcher
+    command: bash -c "while true; do bundle exec exe/calendar_watcher today_events --output=grpc:hiyoco-example:50051; sleep 60; done"
+    volumes:
+      - ./calendar_watcher:/root/.config/calendar_watcher
+    depends_on:
+      - hiyoco-example
+
+  hiyoco-example:
+    build: .
+    container_name: hiyoco-example
+    image: hiyoco-example
+    command: bash -c "bundle exec ruby server.rb | tee >(./filter_before_15minutes.rb | ./filter_not_out_yet.rb | bundle exec ruby post_event_to_sounder.rb 172.21.50.138 50050) >(./filter_not_out_yet.rb | ./once_day.rb | bundle exec ruby post_event_to_informant.rb informant 50052)"
+    ports:
+      - "50051:50051"
+    depends_on:
+      - informant

--- a/examples/server.rb
+++ b/examples/server.rb
@@ -1,0 +1,24 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+require "grpc"
+require "hiyoco/calendar_watcher/service_services_pb"
+
+class FilterServer < Hiyoco::CalendarWatcher::Filter::Service
+  def say_event(e, _unused_call)
+    start_time = Time.at(e.start.dateTime.dateTime.seconds)
+    end_time = Time.at(e.end.dateTime.dateTime.seconds)
+    puts "[\{\"start\":\"#{start_time.strftime("%Y-%m-%dT%H:%M+09:00")}\",\"end\":\"#{end_time.strftime("%Y-%m-%dT%H:%M+09:00")}\",\"summary\":\"#{e.summary}\",\"description\":\"#{e.description}\"\}]"
+    STDOUT.flush
+    Hiyoco::Calendar::Result.new(result: true)
+  end
+end
+
+# main starts an RpcServer that receives requests to GreeterServer at the sample
+# server port.
+def main
+  s = GRPC::RpcServer.new
+  s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
+  s.handle(FilterServer)
+  s.run_till_terminated
+end
+
+main

--- a/examples/server.rb
+++ b/examples/server.rb
@@ -4,9 +4,9 @@ require "hiyoco/calendar_watcher/service_services_pb"
 
 class FilterServer < Hiyoco::CalendarWatcher::Filter::Service
   def say_event(e, _unused_call)
-    start_time = Time.at(e.start.dateTime.dateTime.seconds)
-    end_time = Time.at(e.end.dateTime.dateTime.seconds)
-    puts "[\{\"start\":\"#{start_time.strftime("%Y-%m-%dT%H:%M+09:00")}\",\"end\":\"#{end_time.strftime("%Y-%m-%dT%H:%M+09:00")}\",\"summary\":\"#{e.summary}\",\"description\":\"#{e.description}\"\}]"
+    start_time = Time.at(e.start.dateTime.dateTime.seconds).getlocal("+09:00")
+    end_time = Time.at(e.end.dateTime.dateTime.seconds).getlocal("+09:00")
+    puts "[\{\"start\":\"#{start_time.strftime("%Y-%m-%dT%H:%M%:z")}\",\"end\":\"#{end_time.strftime("%Y-%m-%dT%H:%M%:z")}\",\"summary\":\"#{e.summary}\",\"description\":\"#{e.description}\"\}]"
     STDOUT.flush
     Hiyoco::Calendar::Result.new(result: true)
   end

--- a/services/calendar_watcher/Dockerfile
+++ b/services/calendar_watcher/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.5.1
+
+RUN mkdir -p $HOME/.config/calendar_watcher
+
+COPY lib/ ./lib/
+COPY calendar_watcher.gemspec ./	
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --path=vendor/bundle --binstubs=bin
+
+COPY exe/ ./exe/
+
+CMD [ "bundle", "exec", "exe/calendar_watcher", "help" ]

--- a/services/informant/Dockerfile
+++ b/services/informant/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.5.2
+
+COPY requirements/ ./requirements/
+
+RUN pip install -r ./requirements/development.txt
+
+COPY hiyoco/ ./hiyoco/
+COPY settings.yml ./
+COPY informant_server.py ./
+
+CMD [ "python", "./informant_server.py", "50052" ]


### PR DESCRIPTION
#58 に対するPR

以下の3つのディレクトリ以下に `Dockerfile` を追加した．
+ hiyoco/services/informant/
+ hiyoco/services/calendar_watcher/
+ hiyoco/examples/

また，上記の3つの `Dockerfile` により作成したイメージを用いて，以下の機能を実現する `docker-compose.yml` ファイルを追加した．
+ 朝10時に Slack に今日の予定を投稿する機能
+ 予定開始の15分前に AIY VoiceKit に予定を発言させる機能

`hiyoco/examples` 以下で次のコマンドを実行することで使用できる．なお，以下の前提条件が必要である．
+ 各サービスの proto ファイルがコンパイル済みである
+ informant の `settings.yml` の設定が完了している
+ AIY VoiceKit にて sounder のサービスが起動している
1. Docker イメージの作成
```
  $ docker-compose build
```
2. calendar_watcher の設定
```
  $ docker-compose run calendar_watcher bundle exec exe/calendar_watcher init
  $ docker-compose run calendar_watcher bundle exec exe/calendar_watcher auth
```
3. 起動
```
  $ docker-compose up
```

## 課題
+ protocol buffers により定義された Event 型には配列のような型がないため，1つずつしか予定を送信できない．このため，朝10時に Slack に予定を投稿する機能が以下のようになってしまう．
```
今日の予定は以下のとおりです．
-----
08:40-10:50 予定1
-----
今日の予定は以下のとおりです．
-----
08:00-10:50 予定2
-----
今日の予定は以下のとおりです．
-----
13:00-15:00 予定3
-----
```