### PR TITLE
Enable to send EventCollection

### DIFF
--- a/proto/hiyoco/calendar/event.proto
+++ b/proto/hiyoco/calendar/event.proto
@@ -48,6 +48,13 @@ message Event {
 }
 
 /**
+  Represents event collection
+*/
+message EventCollection {
+  repeated Event events = 1; /// Array of event
+}
+
+/**
   Represents return value of result
 */
 message Result {

--- a/proto/hiyoco/calendar_watcher/service.proto
+++ b/proto/hiyoco/calendar_watcher/service.proto
@@ -18,3 +18,7 @@ service Informant {
 service Filter {
   rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
 }
+
+service Test {
+  rpc SayEvents (hiyoco.calendar.EventCollection) returns (hiyoco.calendar.Result) {}
+}

--- a/proto/hiyoco/calendar_watcher/service.proto
+++ b/proto/hiyoco/calendar_watcher/service.proto
@@ -7,18 +7,7 @@ option java_package = "org.nomlab.hiyoco";
 option java_outer_classname = "CalendarWathcerServiceProtos";
 option csharp_namespace = "Hiyoco.CalendarWatcher.Service";
 
-service Sounder {
-  rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
-}
-
-service Informant {
-  rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
-}
-
 service Filter {
   rpc SayEvent (hiyoco.calendar.Event) returns (hiyoco.calendar.Result) {}
-}
-
-service Test {
   rpc SayEvents (hiyoco.calendar.EventCollection) returns (hiyoco.calendar.Result) {}
 }

--- a/services/calendar_watcher/exe/calendar_watcher_server
+++ b/services/calendar_watcher/exe/calendar_watcher_server
@@ -24,9 +24,12 @@ require "bundler/setup"
 require "grpc"
 require "hiyoco/calendar_watcher/service_services_pb"
 
-class FilterServer < Hiyoco::CalendarWatcher::Filter::Service
-  def say_event(event, _unused_call)
-    puts event.summary
+class TestServer < Hiyoco::CalendarWatcher::Test::Service
+  def say_events(events, _unused_call)
+    events.events.each do |event|
+      puts event.summary
+    end
+
     Hiyoco::Calendar::Result.new(result: true)
   end
 end
@@ -36,7 +39,7 @@ end
 def main
   s = GRPC::RpcServer.new
   s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
-  s.handle(FilterServer)
+  s.handle(TestServer)
   s.run_till_terminated
 end
 

--- a/services/calendar_watcher/exe/filter_service_test_server
+++ b/services/calendar_watcher/exe/filter_service_test_server
@@ -24,7 +24,7 @@ require "bundler/setup"
 require "grpc"
 require "hiyoco/calendar_watcher/service_services_pb"
 
-class TestServer < Hiyoco::CalendarWatcher::Test::Service
+class FilterServiceTestServer < Hiyoco::CalendarWatcher::Filter::Service
   def say_events(events, _unused_call)
     events.events.each do |event|
       puts event.summary
@@ -39,7 +39,7 @@ end
 def main
   s = GRPC::RpcServer.new
   s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
-  s.handle(TestServer)
+  s.handle(FilterServiceTestServer)
   s.run_till_terminated
 end
 

--- a/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
+++ b/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
@@ -27,16 +27,20 @@ class CalendarWatcherCLI < Clian::Cli
     end
 
     if format == "grpc"
-      stub = Hiyoco::CalendarWatcher::Filter::Stub.new("#{host}:#{port}", :this_channel_is_insecure)
+      stub = Hiyoco::CalendarWatcher::Test::Stub.new("#{host}:#{port}", :this_channel_is_insecure)
+      grpc_events = Hiyoco::Calendar::EventCollection.new(events: [])
+
       today_events.each do |ev|
         s = create_gprc_date(ev.start_time)
         e = create_gprc_date(ev.end_time)
         desc = ev.description || ""
 
         grpc_ev = Hiyoco::Calendar::Event.new(start: s, end: e, summary: ev.summary, description: desc)
-        puts stub.say_event(grpc_ev).result
+        grpc_events.events.push(grpc_ev)
       end
 
+      puts stub.say_events(grpc_events).result
+    
     elsif format == "json"
       puts today_events.to_json
 

--- a/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
+++ b/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
@@ -54,7 +54,7 @@ class CalendarWatcherCLI < Clian::Cli
   private
 
   def date_or_datetime(date)
-    date.date_time || date.date
+    date.date_time || DateTime.parse(date.date)
   end
 
   def create_gprc_date(date)

--- a/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
+++ b/services/calendar_watcher/lib/calendar_watcher/command/today_events.rb
@@ -27,7 +27,7 @@ class CalendarWatcherCLI < Clian::Cli
     end
 
     if format == "grpc"
-      stub = Hiyoco::CalendarWatcher::Test::Stub.new("#{host}:#{port}", :this_channel_is_insecure)
+      stub = Hiyoco::CalendarWatcher::Filter::Stub.new("#{host}:#{port}", :this_channel_is_insecure)
       grpc_events = Hiyoco::Calendar::EventCollection.new(events: [])
 
       today_events.each do |ev|


### PR DESCRIPTION
#65 に対する PR である．
### やったこと
event のメッセージを collection で送れるようにするために以下を行った．
+ bd1c90b について
終日の予定の日付が String 型で送信されていた．このため，`services/calendar_watcher/lib/calendar_watcher/command/today_events.rb` を編集し，終日の予定の日付を DateTime 型に変換して送信するようにした．
+ a8bbc0e について
`proto/hiyoco/calendar/event.proto` に EventCollection を追加した．
+ b122d7d について
`proto/hiyoco/calendar_watcher_service.proto` に EventCollection の送受信を行う Test サービスを追加した．
+ eb78535 について
`services/calendar_watcher/lib/calendar_watcher/command/today_events.rb` に EventCollection を gRPC で送信できる機能を追加した．
+ 766fbf2 について
`services/calendar_watcher/exe/calendar_watcher_server` に EventCollection を gRPC で送れるかテストを作成し，動作確認をした．

### EventCollection の実現方法
Protocol Buffers の `repeated` フィールドを用いることで実現できる．`repeated` を用いると，メッセージを配列に格納しまとめることができる．使用例として`proto/hiyoco/calendar/event.proto` の一部を以下に示す．
```
message EventCollection {
  repeated Event events = 1; /// Array of event
}
```
