### PR TITLE
Fix location of generate_docs.sh in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           name: Generate docs/ in proto/
           command: |
             set +e
-            cd proto
+            cd proto/scripts
             bash ./generate_docs.sh --local
       - run:
           name: Push to GitHub


### PR DESCRIPTION
CircleCI のテストが Fail していたため確認したところ． Circle Ci の config.yml 内のコマンド実行場所が `/proto` となっており異なっていた．このため， `/proto/scripts` 以下でコマンドを実行するよう修正した．