### PR TITLE
Upgrade python library 'requests' for informant

### DIFF
--- a/services/informant/requirements/common.txt
+++ b/services/informant/requirements/common.txt
@@ -4,6 +4,6 @@ grpcio==1.12.0
 idna==2.6
 protobuf==3.5.2.post1
 PyYAML==3.12
-requests==2.18.4
+requests==2.20.0
 six==1.11.0
 urllib3==1.22


### PR DESCRIPTION
informant で使用している Python ライブラリ `requests` のバージョンが古かったため更新した．