### PR TITLE
20181127 filter

### DIFF
--- a/services/filter/filter.gemspec
+++ b/services/filter/filter.gemspec
@@ -9,15 +9,15 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Nomura Laboratory, Eiji Yamamoto, Yoshinari Nonura"]
   spec.email         = ["nomura.laboratory@gmail.com"]
 
-  spec.summary       = %q{TODO: Edit event received with gRPC, and send event by gRPC．}
-  spec.description   = %q{TODO: Edit event received with gRPC, and send event by gRPC．}
+  spec.summary       = %q{Edit event received with gRPC, and send event by gRPC．}
+  spec.description   = %q{Edit event received with gRPC, and send event by gRPC．}
   spec.homepage      = "https://github.com/nomlab/hiyoco"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata["allowed_push_host"] = "Set to 'http://mygemserver.com'"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."

--- a/services/filter/lib/filter/action.rb
+++ b/services/filter/lib/filter/action.rb
@@ -1,0 +1,13 @@
+class Action
+  def initialize(dsl)
+    dsl_array = dsl.split(":")
+    @type = dsl_array[0]
+    @event_item = dsl_array[1]
+  end
+
+  def apply(e)
+    eval("e.#{event_item} = ''") if @type == "hide"
+  end
+
+  attr_accessor :type, :event_item
+end

--- a/services/filter/lib/filter/filter_server.rb
+++ b/services/filter/lib/filter/filter_server.rb
@@ -1,5 +1,7 @@
+# coding: utf-8
 this_dir = File.expand_path(File.dirname(__FILE__))
 lib_dir = File.join(this_dir, '../proto')
+$LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 $LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
 
 require 'grpc'
@@ -7,15 +9,14 @@ require "hiyoco/calendar/event_pb"
 require "hiyoco/filter/service_pb"
 require "hiyoco/filter/service_services_pb"
 require "hiyoco/informant/service_services_pb"
+require "funnel"
 
 class FilterServer < Hiyoco::Filter::Filter::Service
   def say_event(e, _unused_call)
-    stub = Hiyoco::Informant::Informant::Stub.new('0.0.0.0:50051', :this_channel_is_insecure)
-    start_time = Time.at(e.start.date.date.seconds)
-    end_time = Time.at(e.end.date.date.seconds)
-    str = "Summary:#{e.summary}\nDescription:#{e.description}\nStart at #{start_time.strftime("%Y-%m-%d %H:%M")}\nEnd at #{end_time.strftime("%Y-%m-%d %H:%M")}\n"
-    message = stub.say_event(Hiyoco::Calendar::Text.new(body: str )).result
-    puts message
+    dsl = ["summary:打合せ", "hide:description", "slack"]
+    funnel = Funnel.new(dsl)
+    #funnel.outlet.apply(e) # for confirm raw event
+    funnel.apply(e)
   end
 end
 

--- a/services/filter/lib/filter/funnel.rb
+++ b/services/filter/lib/filter/funnel.rb
@@ -1,0 +1,20 @@
+require "matcher"
+require "action"
+require "outlet"
+
+class Funnel
+  def initialize(dsl)
+    @matcher = Matcher.new(dsl[0])
+    @action = Action.new(dsl[1])
+    @outlet = Outlet.new(dsl[2])
+  end
+
+  def apply(e)
+    if @matcher.apply(e) then
+      @action.apply(e)
+    end
+    @outlet.apply(e)
+  end
+
+  attr_accessor :matcher, :action, :outlet
+end

--- a/services/filter/lib/filter/matcher.rb
+++ b/services/filter/lib/filter/matcher.rb
@@ -1,0 +1,13 @@
+class Matcher
+  def initialize(dsl)
+    dsl_array = dsl.split(":")
+    @event_item = dsl_array[0]
+    @arg = dsl_array[1]
+  end
+
+  def apply(e)
+    return true if eval("e.#{event_item}.include?(\"#{arg}\")")
+  end
+
+  attr_accessor :event_item, :arg
+end

--- a/services/filter/lib/filter/outlet.rb
+++ b/services/filter/lib/filter/outlet.rb
@@ -1,0 +1,20 @@
+class Outlet
+  def initialize(dsl)
+    dsl_array = dsl.split(":")
+    @type = dsl_array[0]
+    @dest = dsl_array[1]
+  end
+
+  def apply(e)
+    if @type == "slack" then
+      start_time = Time.at(e.start.date.date.seconds)
+      end_time = Time.at(e.end.date.date.seconds)
+      stub = Hiyoco::Informant::Informant::Stub.new('0.0.0.0:50051', :this_channel_is_insecure)
+      str = "Summary:#{e.summary}\nDescription:#{e.description}\nStart at #{start_time.strftime("%Y-%m-%d %H:%M")}\nEnd at #{end_time.strftime("%Y-%m-%d %H:%M")}\n"
+      message = stub.say_event(Hiyoco::Calendar::Text.new(body: str )).result
+      puts message
+    end
+  end
+
+  attr_accessor :type, :dest
+end

--- a/services/filter/lib/test/filter_client.rb
+++ b/services/filter/lib/test/filter_client.rb
@@ -21,8 +21,8 @@ end
 def main
   start_time = Time.new(2018, 8, 6, 13, 30, 0, "+09:00")
   end_time = Time.new(2018, 8, 6, 15, 30, 0, "+09:00")
-  summary = "第160回GN談話会"
-  description = ""
+  summary = "第160回GN検討打合せ"
+  description = "test event"
 
   stub = Hiyoco::Filter::Filter::Stub.new('0.0.0.0:50050', :this_channel_is_insecure)
   ev = Hiyoco::Calendar::Event.new(start: create_date(start_time), end: create_date(end_time), summary: summary, description: description)


### PR DESCRIPTION
### やったこと
+ プロトタイプとして，DSLによる予定共有の処理をfilterサービスに実装した．今回は，`summary:打合せ，hide:description, slack`というDSLを適用する処理を実装した．
+ DSLの利用にあたり，以下の4つのクラスを作成した．
    + matcher: どの予定を編集するかを情報としてもつ．(例: summary:打合せ)
    + action: 予定をどのように編集するかを情報としてもつ．(例: hide:description)
    + outlet: 予定をどのように公開するかを情報としてもつ．(例: slack)
    + funnel: 上記のmatcher, action, outletをもつ．
+ filterサービスは以下の流れで処理をする．
    1. Funnel.new(dsl)で，与えられたDSLを分解し，matcher, action, outletを生成する．
    1. Funnel.apply(event)で，eventに対してfunnelを適用する．これにより，予定の編集と公開が行われる．

### 今後の課題
+ matcher, action, outletの処理の詳細化
    + 現在は`summary:打合せ，hide:description, slack`というDSLを処理することに依存した処理になっているため，他のDSLも利用できるように処理を詳細化する必要がある．
+ EventCollectionの受信と送信
    + 現在, filterサービスはevent.protoで定義されたeventを受信して，Textとして予定を送信している．calendar_watcherはEventの配列であるEventCollectionの送信が行えるため，filterサービスもEventCollectionの受信と送信が行える必要がある．